### PR TITLE
fix: copy .claude/commands to runner environment

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Claude commands
+        run: |
+          mkdir -p ~/.claude/commands
+          cp -r .claude/commands/* ~/.claude/commands/
+          ls -la ~/.claude/commands/
+
       - name: Run Claude Issue Triage
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
The /label-issue command defined in .claude/commands/label-issue.md was not accessible in the GitHub Actions runner environment.

Add setup step to copy .claude/commands to ~/.claude/commands so the /label-issue slash command is available.